### PR TITLE
Screen positioning issue fix

### DIFF
--- a/shell.qml
+++ b/shell.qml
@@ -78,9 +78,19 @@ FreezeScreen {
     }
 
     function processScreenshot(x, y, width, height) {
+        const monitors = Hyprland.monitors.values
+
+        var monitorOffset = undefined
+        for (const monitor of monitors) {
+            if (!monitorOffset) monitorOffset = monitor
+            else if (monitor.x < monitorOffset.x) monitorOffset = monitor
+            else if (monitor.x == monitorOffset.x) monitorOffset = monitor.y < monitorOffset.y ? monitorOffset : monitor
+            else continue
+        }
+
         const scale = hyprlandMonitor.scale
-        const scaledX = Math.round((x + root.hyprlandMonitor.x) * scale)
-        const scaledY = Math.round((y + root.hyprlandMonitor.y) * scale)
+        const scaledX = Math.round((x + root.hyprlandMonitor.x - monitorOffset.x) * scale)
+        const scaledY = Math.round((y + root.hyprlandMonitor.y - monitorOffset.y) * scale)
         const scaledWidth = Math.round(width * scale)
         const scaledHeight = Math.round(height * scale)
 


### PR DESCRIPTION
Some hyprland configs have weird screen positioning

Normally we expect screen positions start from 0x0 but my screen config looks like

`
monitor = DP-1, 1920x1080@165, 0x0, 1 #First screen

monitor = HDMI-A-1, 1920x1080@72, -1920x0, 1 #Second Screen
`

If the screen on the left is not at 0x0, problem occurs. Sometimes when trying to take a screenshot from screen1, it takes one from screen2 at the same coordinates or gives an error because it goes outside the boundary.

If your Hyprland configuration is normal, this code change will not affect you because x and y will be 0. It should only affect those with weird configurations.